### PR TITLE
Sync tslint with balena/process

### DIFF
--- a/config/tslint.json
+++ b/config/tslint.json
@@ -1,30 +1,34 @@
 {
-  "extends": [
-    "tslint:recommended",
-    "tslint-config-prettier"
-  ],
-  "rules": {
-    "jsdoc-format": true,
-    "object-literal-sort-keys": false,
-    "only-arrow-functions": [false],
-    "max-classes-per-file": [false],
-    "max-line-length": [180],
-    "member-access": false,
-    "member-ordering": [false],
-    "no-shadowed-variable": false,
-    "no-var-requires": true,
-    "no-angle-bracket-type-assertion": false,
-    "no-console": [false],
-    "no-empty-interface": false,
-    "no-string-literal": false,
-    "interface-name": [false],
-    "interface-over-type-literal": false,
-    "variable-name": [
-      true,
-      "ban-keywords",
-      "check-format",
-      "allow-leading-underscore",
-      "allow-pascal-case"
-    ]
-  }
+	"extends": "tslint:recommended",
+	"rules": {
+		"indent": [
+			true,
+			"tabs"
+		],
+		"jsdoc-format": true,
+		"whitespace": [
+			false,
+			"check-type"
+		],
+		"object-literal-sort-keys": false,
+		"only-arrow-functions": false,
+		"quotemark": [
+			true,
+			"single",
+			"avoid-escape"
+		],
+		"no-var-requires": true,
+		"arrow-parens": false,
+		"max-classes-per-file": false,
+		"no-console": false,
+		"no-string-literal": false,
+		"interface-name": false,
+		"variable-name": [
+			true,
+			"ban-keywords",
+			"check-format",
+			"allow-leading-underscore",
+			"allow-pascal-case"
+		]
+	}
 }

--- a/test/typescript/prettier/lintme.ts
+++ b/test/typescript/prettier/lintme.ts
@@ -9,7 +9,7 @@ const x = a
 	? {
 			key: 'A',
 			value: 'B',
-	  }
+		}
 	: {};
 
 interface A {
@@ -17,7 +17,7 @@ interface A {
 		| {
 				key: string;
 				value: string;
-		  }
+			}
 		| string;
 }
 

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,3 @@
+{
+	"extends": "./config/tslint.json"
+}


### PR DESCRIPTION
Connects-to: #31 

Copying rules from https://github.com/balena-io/process/blob/master/process/TypeScript_Coding_Guide.md#rules

Few questions:
1. https://www.npmjs.com/package/tslint-config-prettier is not mentioned in the process, but I see it used all over the place, should we keep it (and update process doc)
1. there are some rules, like `"only-arrow-functions"` that I don't see explained, nor their benefit - should we keep them? Is there a compelling argument for them?
1. tslint in resin-ui have a bunch of more rules, do we want to carry them over?
1. how about we add some TSX-related rules, like https://github.com/palantir/tslint-react ? - used JSX version of this config and it was fine

My personal preference is strict linter for the sake of consistency.