### PR TITLE
Fix tslint extending and synchronize balena/process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,6 @@ buildSteps: &buildSteps
         - ./node-*
 
 jobs:
-  node-4:
-    docker:
-      - image: circleci/node:4
-    working_directory: ~/node-4
-    steps: *buildSteps
-
   node-6:
     docker:
       - image: circleci/node:6
@@ -61,11 +55,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - node-4:
-          # Run for all tags (required to allow the deploy to trigger on version tags)
-          filters:
-            tags:
-              only: /.*/
       - node-6:
           # Run for all tags (required to allow the deploy to trigger on version tags)
           filters:
@@ -84,7 +73,6 @@ workflows:
       - deploy:
           # Deploy passing builds if they're tagged with a version
           requires:
-            - node-4
             - node-6
             - node-8
             - node-10

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,4 @@
+// prettier doesn't support "extends" so we have to load it manually
 const fs = require('fs');
 
 module.exports = JSON.parse(fs.readFileSync('./config/.prettierrc', 'utf8'));

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+const fs = require('fs');
+
+module.exports = JSON.parse(fs.readFileSync('./config/.prettierrc', 'utf8'));

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Overview
 
 `resin-lint` uses Resin's `coffeelint.json`, `tslint.json` and `.prettierrc`.
 If a `coffeelint.json` or `tslint.json` is found in the to-be-linted project
-directory or its parents then the rules found in it will override the default `resin-lint` ones.
+directory or its parents then the rules found in it will be merged with the default `resin-lint` ones.
 Another way to to override the default resin-lint rules is by specifying a configuration
 file with the `-f` parameter.
 
@@ -62,6 +62,46 @@ You can use this module as:
     Done!
 
   ```
+
+3. A development dependency, that will get picked up by your IDE/Editor coffeelint/tslint/prettier.
+
+Manually create these config files in your project root:
+
+`tslint.json`
+
+```json
+// if using prettier in your project
+{
+	"extends": [
+		"resin-lint/config/tslint-prettier.json"
+	]
+}
+
+// plain TypeScript
+{
+	"extends": [
+		"resin-lint/config/tslint.json"
+	]
+}
+```
+
+For coffeelint create `coffeelint.json`
+
+```json
+{
+	"extends": [
+		"resin-lint/config/coffeelint.json"
+	]
+}
+```
+
+For prettier config create `.prettierrc.js`
+
+```js
+const fs = require('fs');
+
+module.exports = JSON.parse(fs.readFileSync('./node_modules/resin-lint/config/.prettierrc', 'utf8'));
+```
 
 Support
 -------

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,5 @@
+{
+	"extends": [
+		"./config/coffeelint.json"
+	]
+}

--- a/config/tslint-prettier.json
+++ b/config/tslint-prettier.json
@@ -1,0 +1,6 @@
+{
+	"extends": [
+		"./tslint.json",
+		"tslint-config-prettier"
+	]
+}

--- a/config/tslint.json
+++ b/config/tslint.json
@@ -1,30 +1,27 @@
 {
-  "extends": [
-    "tslint:recommended",
-    "tslint-config-prettier"
-  ],
-  "rules": {
-    "jsdoc-format": true,
-    "object-literal-sort-keys": false,
-    "only-arrow-functions": [false],
-    "max-classes-per-file": [false],
-    "max-line-length": [180],
-    "member-access": false,
-    "member-ordering": [false],
-    "no-shadowed-variable": false,
-    "no-var-requires": true,
-    "no-angle-bracket-type-assertion": false,
-    "no-console": [false],
-    "no-empty-interface": false,
-    "no-string-literal": false,
-    "interface-name": [false],
-    "interface-over-type-literal": false,
-    "variable-name": [
-      true,
-      "ban-keywords",
-      "check-format",
-      "allow-leading-underscore",
-      "allow-pascal-case"
-    ]
-  }
+	"extends": "tslint:recommended",
+	"rules": {
+			"indent": [ true, "tabs" ],
+			"jsdoc-format": true,
+			"whitespace": [
+					false,
+					"check-type"
+			],
+			"object-literal-sort-keys": false,
+			"only-arrow-functions": false,
+			"quotemark": [true, "single", "avoid-escape"],
+			"no-var-requires": true,
+			"arrow-parens": false,
+			"max-classes-per-file": false,
+			"no-console": false,
+			"no-string-literal": false,
+			"interface-name": false,
+			"variable-name": [
+					true,
+					"ban-keywords",
+					"check-format",
+					"allow-leading-underscore",
+					"allow-pascal-case"
+			]
+	}
 }

--- a/config/tslint.json
+++ b/config/tslint.json
@@ -1,27 +1,24 @@
 {
 	"extends": "tslint:recommended",
 	"rules": {
-			"indent": [ true, "tabs" ],
-			"jsdoc-format": true,
-			"whitespace": [
-					false,
-					"check-type"
-			],
-			"object-literal-sort-keys": false,
-			"only-arrow-functions": false,
-			"quotemark": [true, "single", "avoid-escape"],
-			"no-var-requires": true,
-			"arrow-parens": false,
-			"max-classes-per-file": false,
-			"no-console": false,
-			"no-string-literal": false,
-			"interface-name": false,
-			"variable-name": [
-					true,
-					"ban-keywords",
-					"check-format",
-					"allow-leading-underscore",
-					"allow-pascal-case"
-			]
+		"indent": [true, "tabs"],
+		"jsdoc-format": true,
+		"whitespace": [false, "check-type"],
+		"object-literal-sort-keys": false,
+		"only-arrow-functions": false,
+		"quotemark": [true, "single", "avoid-escape"],
+		"no-var-requires": true,
+		"arrow-parens": false,
+		"max-classes-per-file": false,
+		"no-console": false,
+		"no-string-literal": false,
+		"interface-name": false,
+		"variable-name": [
+			true,
+			"ban-keywords",
+			"check-format",
+			"allow-leading-underscore",
+			"allow-pascal-case"
+		]
 	}
 }

--- a/lib/resin-lint.ts
+++ b/lib/resin-lint.ts
@@ -9,6 +9,7 @@ import * as optimist from 'optimist';
 import * as path from 'path';
 import * as prettier from 'prettier';
 import * as tslint from 'tslint';
+import { IConfigurationFile } from 'tslint/lib/configuration';
 
 interface ResinLintConfig {
 	configPath: string;
@@ -31,6 +32,12 @@ const configurations: { [key: string]: ResinLintConfig } = {
 		extensions: ['ts', 'tsx'],
 		lang: 'typescript',
 	},
+	typescriptPrettier: {
+		configPath: path.join(__dirname, '../config/tslint-prettier.json'),
+		configFileName: 'tslint.json',
+		extensions: ['ts', 'tsx'],
+		lang: 'typescript',
+	},
 };
 
 const prettierConfigPath = path.join(__dirname, '../config/.prettierrc');
@@ -44,22 +51,22 @@ const prettierConfigPath = path.join(__dirname, '../config/.prettierrc');
  * until it contains a package.json
  */
 const getPackageJsonDir = function(dir: string): string {
-	let name = findFile('package.json', dir);
+	const name = findFile('package.json', dir);
 	if (name === null) {
 		throw new Error('Could not find package.json!');
 	}
 	return path.dirname(name);
 };
 
-const read = function(path: string): string {
-	let realPath = fs.realpathSync(path);
+const read = function(filepath: string): string {
+	const realPath = fs.realpathSync(filepath);
 	return fs.readFileSync(realPath).toString();
 };
 
 const findFile = function(name: string, dir?: string): string | null {
 	dir = dir || process.cwd();
-	let filename = path.join(dir, name);
-	let parent = path.dirname(dir);
+	const filename = path.join(dir, name);
+	const parent = path.dirname(dir);
 	if (fs.existsSync(filename)) {
 		return filename;
 	} else if (dir === parent) {
@@ -117,7 +124,6 @@ const lintTsFiles = function(
 	config: {},
 	prettierConfig?: prettier.Options,
 ): number {
-	const parsedConfig = tslint.Configuration.parseConfigFile(config);
 	const linter = new tslint.Linter({
 		fix: false,
 		formatter: 'stylish',
@@ -132,7 +138,7 @@ const lintTsFiles = function(
 				return 1;
 			}
 		}
-		linter.lint(file, source, parsedConfig);
+		linter.lint(file, source, config as IConfigurationFile);
 	}
 
 	const errorReport = linter.getResult();
@@ -174,7 +180,7 @@ export const lint = function(passedParams: any) {
 			.usage('Usage: resin-lint [options] [...]')
 			.describe(
 				'f',
-				'Specify a linting config file to override resin-lint rules',
+				'Specify a linting config file to extend and override resin-lint rules',
 			)
 			.describe('p', 'Print default resin-lint linting rules')
 			.describe(
@@ -210,7 +216,7 @@ export const lint = function(passedParams: any) {
 						.then(function(deps) {
 							if (deps.length > 0) {
 								console.log(`${deps.length} unused dependencies:`);
-								for (let dep of deps) {
+								for (const dep of deps) {
 									console.log(`\t${dep}`);
 								}
 								process.exit(1);
@@ -223,8 +229,12 @@ export const lint = function(passedParams: any) {
 		})
 			.then(function() {
 				let configOverridePath;
-				const resinLintConfiguration = options.argv.typescript
-					? configurations.typescript
+				const prettierCheck = options.argv.prettier !== false;
+				const typescriptCheck = options.argv.typescript;
+				const resinLintConfiguration = typescriptCheck
+					? prettierCheck
+						? configurations.typescriptPrettier
+						: configurations.typescript
 					: configurations.coffeescript;
 
 				if (options.argv.p) {
@@ -234,7 +244,13 @@ export const lint = function(passedParams: any) {
 					process.exit(0);
 				}
 
-				let config = parseJSON(resinLintConfiguration.configPath);
+				// TSLint config needs to be loaded with `loadConfigurationFromPath`
+				// Coffeelint needs to be loaded as a plain file
+				let config: {} = typescriptCheck
+					? tslint.Configuration.loadConfigurationFromPath(
+							resinLintConfiguration.configPath,
+					  )
+					: parseJSON(resinLintConfiguration.configPath);
 
 				if (options.argv.f) {
 					configOverridePath = fs.realpathSync(options.argv.f);
@@ -245,16 +261,25 @@ export const lint = function(passedParams: any) {
 				}
 
 				if (configOverridePath) {
-					// Override default config
-					const configOverride = parseJSON(configOverridePath);
-					config = merge.recursive(config, configOverride);
+					// Extend/override default config
+					if (typescriptCheck) {
+						const configOverride = tslint.Configuration.loadConfigurationFromPath(
+							configOverridePath,
+						);
+						config = tslint.Configuration.extendConfigurationFile(
+							config as IConfigurationFile,
+							configOverride,
+						);
+					} else {
+						const configOverride = parseJSON(configOverridePath);
+						config = merge.recursive(config, configOverride);
+					}
 				}
 
 				const paths = options.argv._;
 
 				// optimist converts all --no-xyz args to a argv.xyz === false
-				resinLintConfiguration.prettierCheck = options.argv.prettier !== false;
-
+				resinLintConfiguration.prettierCheck = prettierCheck;
 				return runLint(resinLintConfiguration, paths, config);
 			})
 			.return();

--- a/lib/resin-lint.ts
+++ b/lib/resin-lint.ts
@@ -229,6 +229,7 @@ export const lint = function(passedParams: any) {
 		})
 			.then(function() {
 				let configOverridePath;
+				// optimist converts all --no-xyz args to a argv.xyz === false
 				const prettierCheck = options.argv.prettier !== false;
 				const typescriptCheck = options.argv.typescript;
 				const resinLintConfiguration = typescriptCheck
@@ -278,7 +279,6 @@ export const lint = function(passedParams: any) {
 
 				const paths = options.argv._;
 
-				// optimist converts all --no-xyz args to a argv.xyz === false
 				resinLintConfiguration.prettierCheck = prettierCheck;
 				return runLint(resinLintConfiguration, paths, config);
 			})

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "prepublishOnly": "npm run test",
     "prettify": "prettier --config ./config/.prettierrc --write \"lib/**/*.ts\"",
     "test": "npm run build && npm run test:coffeescript && npm run test:typescript && npm run test:typescript-no-prettier",
-    "test:coffeescript": " ./bin/resin-lint test/coffeescript",
-    "test:typescript": "./bin/resin-lint test/typescript/prettier --typescript",
-    "test:typescript-no-prettier": "./bin/resin-lint test/typescript/no-prettier --typescript --no-prettier"
+    "test:coffeescript": " ./bin/resin-lint test/coffeescript -i",
+    "test:typescript": "./bin/resin-lint test/typescript/prettier --typescript -i",
+    "test:typescript-no-prettier": "./bin/resin-lint test/typescript/no-prettier --typescript -i --no-prettier"
   },
   "keywords": [
     "resin",

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,5 @@
+{
+	"extends": [
+		"./config/tslint-prettier.json"
+	]
+}


### PR DESCRIPTION
Connects-to: #31 
Connects-to: #33 

Continued from #32 

1. fixed `"extends"` rules being ignored in tslint
1. adds lint configs for the library itself
1. fixed linter issues in resin-lint.ts
1. adds a static `.tslint-prettier.json` rules - idea being you should extend them in projects

Merging this will most likely cause some linting failures across all projects depending on this library as we have false positives.