### PR TITLE
Remove member-ordering flag

### DIFF
--- a/config/tslint.json
+++ b/config/tslint.json
@@ -13,6 +13,7 @@
 		"no-console": false,
 		"no-string-literal": false,
 		"interface-name": false,
+		"member-ordering": false,
 		"variable-name": [
 			true,
 			"ban-keywords",


### PR DESCRIPTION
This requires private methods to be at the top of the file, which makes
no sense when somebody might be looking at the code. They're going to
want to see the public methods in most cases so it makes sense to have
those at the top.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>