### PR TITLE
add exception for 'no unused expression' for chai test syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "prettier": "^1.16.4",
     "tslint": "^5.15.0",
     "tslint-config-prettier": "^1.18.0",
+    "tslint-no-unused-expression-chai": "^0.1.4",
     "typescript": "^3.4.3"
   },
   "devDependencies": {

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,6 @@
 {
 	"extends": [
-		"./config/tslint-prettier.json"
+		"./config/tslint-prettier.json",
+		"tslint-no-unused-expression-chai"
 	]
 }


### PR DESCRIPTION
See the npm package here: https://www.npmjs.com/package/tslint-no-unused-expression-chai

This means that lint won't get mad at chai tests for using the chai syntax (and it *only* excepts chai syntax, not anything else)

Change-type: patch
Signed-off-by: Nick Payne <nickp@balena.io>