### PR TITLE
Add mocha tests linting

### DIFF
--- a/lib/mocha-tests-lint.ts
+++ b/lib/mocha-tests-lint.ts
@@ -1,0 +1,44 @@
+import * as Bluebird from 'bluebird';
+import * as fs from 'fs';
+
+// Mocha tests linter results.
+// When isError is set to true, the message contains details about found errors.
+export class MochaListResult {
+	constructor(
+		public readonly message: string,
+		public readonly isError: boolean,
+	) {}
+}
+
+const checkPattern = /(describe|it)\.only/;
+
+// Check if files in the test directory don't contain describe.only or it.only statements
+// to ensure that an accidental commit does not prevent all the tests from running.
+export async function lintMochaTests(
+	scripts: string[],
+): Promise<MochaListResult> {
+	let errorsFound = false;
+	let message = '';
+
+	const readFile = Bluebird.promisify(fs.readFile);
+
+	const allCheckPromises = scripts.map(async scriptPath => {
+		const content = (await readFile(scriptPath)).toString();
+		const lines = content.split('\n');
+		for (let ln = 0; ln < lines.length; ln++) {
+			const res = checkPattern.exec(lines[ln]);
+			if (res) {
+				errorsFound = true;
+				message += `File ${scriptPath}, line ${ln}: found ${res[0]}\n`;
+			}
+		}
+	});
+
+	try {
+		await Promise.all(allCheckPromises);
+		return new MochaListResult(errorsFound ? message : 'OK', errorsFound);
+	} catch (e) {
+		console.error(e);
+		return new MochaListResult(`Error reading input files: ${e.message}`, true);
+	}
+}


### PR DESCRIPTION
As suggested by @Page- 
https://www.flowdock.com/app/rulemotion/resin-tech/messages/5050379

Change-type: minor
Signed-off-by: Roman Mazur <roman@balena.io>

Examples:
```
$ resin-lint --tests ./test/
  ✓ test/00-init.coffee
  ✓ test/01-constants.spec.coffee
  ✓ test/02-db.spec.coffee
  ✓ test/03-config.spec.coffee

✓ Ok! » 0 errors and 0 warnings in 25 files

Mocha tests check FAILED!
File test/01-constants.spec.coffee, line 4: found describe.only

$ resin-lint --typescript --tests ./test/


Mocha tests check FAILED!
File test/local-mode.ts, line 301: found describe.only
File test/local-mode.ts, line 312: found it.only
```

I can check eslint plugin alternatives later - for now this change can help with keeping checks consistent across the repos.