### PR TITLE
Specify tsconfigRootDir so local configs are used

### DIFF
--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -45,6 +45,7 @@ module.exports = tseslint.config(
 
 			parserOptions: {
 				project: 'tsconfig.json',
+				tsconfigRootDir: './',
 				ecmaFeatures: {
 					jsx: true,
 				},

--- a/lib/balena-lint.ts
+++ b/lib/balena-lint.ts
@@ -272,6 +272,7 @@ export const lint = async (passedParams: any) => {
 			languageOptions: {
 				parserOptions: {
 					project: argv.t,
+					tsconfigRootDir: './',
 				},
 			},
 		};

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "node ./bin/balena-lint -t tsconfig.json lib/ config/eslint.config.js",
     "prepublish": "require-npm4-to-publish",
     "prepublishOnly": "npm run test",
-    "lint-fix": "node ./bin/balena-lint -t tsconfig.json --fix -e ts -e js -t tsconfig.json lib/ config/eslint.config.js",
+    "lint-fix": "node ./bin/balena-lint -t tsconfig.json --fix -e ts -e js lib/ config/eslint.config.js",
     "test": "npm run build && npm run test:typescript",
     "test:typescript": "node ./bin/balena-lint -t tsconfig.json test/typescript/prettier -i",
     "prepare": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module"


### PR DESCRIPTION
Change-type: patch

---

Currently `npx balena-lint -t <local-tsconfig>` calls fail with something like:
```
  0:0  error  Parsing error: error TS5012: Cannot read file '/home/josh/git/foobar/node_modules/@balena/lint/build/tsconfig.dev.json': ENOENT: no such file or directory, open '/home/josh/git/foobar/node_modules/@balena/lint/build/tsconfig.dev.json
```

See this PR's CI output for an example: https://github.com/balena-io-modules/abstract-sql-to-typescript/pull/98

This is most likely caused by an upstream change to start inferring `tsconfigRootDir`: https://github.com/typescript-eslint/typescript-eslint/pull/11370